### PR TITLE
Use ‘UTF-8’ instead of ‘utf8’

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function SSEBroadcaster(options) {
     this._channels = {}
 
     if (!opts.encoding)
-        opts.encoding = 'utf8'
+        opts.encoding = 'UTF-8'
 
     if (opts.compression === true)
         this._compress = compression()

--- a/test/headers.js
+++ b/test/headers.js
@@ -42,7 +42,7 @@ function listener(req, res) {
 var expected = [
     {
         'cache-control': 'no-cache',
-        'content-type': 'text/event-stream; charset=utf8',
+        'content-type': 'text/event-stream; charset=UTF-8',
         connection: 'keep-alive'
     },
     {
@@ -52,7 +52,7 @@ var expected = [
     },
     {
         'cache-control': 'no-transform',
-        'content-type': 'text/event-stream; charset=utf8',
+        'content-type': 'text/event-stream; charset=UTF-8',
         connection: 'keep-alive'
     },
     {


### PR DESCRIPTION
@abacon and I discovered that the charset "utf8" does not work on chrome and had to use "utf-8" or "UTF-8". As chrome suggests the uppercase one, we figured we'd make this the default.
